### PR TITLE
Jhs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ dependencies {
 
 - application.properties
 ```
-jwt.token.secret= //64byte 이상 string Key 필요
+jwt.token.secret.access= //64byte 이상의 secret key
+jwt.token.secret.refresh=
 spring.datasource.url=jdbc:h2:~/testdb
 spring.datasource.driverClassName=org.h2.Driver
 spring.datasource.username=sa

--- a/src/main/java/socketTest/socketTestspring/config/SecurityConfig.java
+++ b/src/main/java/socketTest/socketTestspring/config/SecurityConfig.java
@@ -38,7 +38,7 @@ public class SecurityConfig {
                         .requestMatchers("api/users/login","api/users/join").permitAll()
                         .requestMatchers(HttpMethod.POST,"api/**").authenticated() //api 경로의 post 방식은 인가 필요
                         .requestMatchers("ws").authenticated() //stomp handshake
-                ) //TODO : authenticated() denied 시 아무 일도 일어나지 않음. 클라이언트에게 알림을 보내야 할 듯?
+                )
 
                 .sessionManagement(sessionManagement -> sessionManagement
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS)) //STATELESS 로 설정함 으로서 세션 사용 X ,JWT 토큰을 사용할 것이기 때문

--- a/src/main/java/socketTest/socketTestspring/controller/MemberController.java
+++ b/src/main/java/socketTest/socketTestspring/controller/MemberController.java
@@ -33,4 +33,9 @@ public class MemberController {
         String token = memberService.login(memberLoginRequest.memberId(), memberLoginRequest.memberPassword());
         return MyResponse.success(new MemberLoginResponse(token));
     }
+
+    @PostMapping("/refresh")
+    public String refresh(@RequestBody MemberLoginRequest memberLoginRequest){
+        return "미구현 : refresh 요청 경로";
+    }
 }

--- a/src/main/java/socketTest/socketTestspring/domain/Member.java
+++ b/src/main/java/socketTest/socketTestspring/domain/Member.java
@@ -31,7 +31,7 @@ public class Member {
         this.memberId = memberId;
         this.memberPassword = memberPassword;
         this.memberName = memberName;
-        this.role = MemberRole.ROLE_NOT_PERMITTED;
+        this.role = MemberRole.ROLE_USER;
     }
 
     public Member(MemberJoinRequest memberJoinRequest){

--- a/src/main/java/socketTest/socketTestspring/domain/MemberRole.java
+++ b/src/main/java/socketTest/socketTestspring/domain/MemberRole.java
@@ -2,5 +2,5 @@ package socketTest.socketTestspring.domain;
 
 //인증 Service 생성하여 로그인한 유저에게 Role 부여하는 기능 구현. 현재 모든 유저들은 ROLE_NOT_PERMITTED 로 등록됨
 public enum MemberRole {
-    ROLE_NOT_PERMITTED, ROLE_USER, ROLE_ADMIN
+    ROLE_USER, ROLE_ADMIN
 }

--- a/src/main/java/socketTest/socketTestspring/exception/MyException.java
+++ b/src/main/java/socketTest/socketTestspring/exception/MyException.java
@@ -2,12 +2,12 @@ package socketTest.socketTestspring.exception;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import socketTest.socketTestspring.exception.myExceptions.GameRuleErrorCode;
+import socketTest.socketTestspring.exception.myExceptions.ErrorCode;
 
 @Getter
 @AllArgsConstructor
 public class MyException extends RuntimeException{
-    private final GameRuleErrorCode errorCode;
+    private final ErrorCode errorCode;
     private final String message;
 
     @Override

--- a/src/main/java/socketTest/socketTestspring/exception/myExceptions/JwtErrorCode.java
+++ b/src/main/java/socketTest/socketTestspring/exception/myExceptions/JwtErrorCode.java
@@ -6,9 +6,10 @@ import org.springframework.http.HttpStatus;
 
 @AllArgsConstructor
 @Getter
-public enum GameRuleErrorCode implements ErrorCode {
-    //GAME RULES
-    INVALID_CARD_SUBMISSION(HttpStatus.BAD_REQUEST, "손에 없는 카드를 제출했습니다");
+public enum JwtErrorCode implements ErrorCode {
+    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다"),
+    TOKEN_NOT_EXIST(HttpStatus.BAD_REQUEST, "토큰이 없습니다"),
+    BAD_TOKEN(HttpStatus.BAD_REQUEST, "인증 실패");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/socketTest/socketTestspring/exception/myExceptions/ServerConnectionErrorCode.java
+++ b/src/main/java/socketTest/socketTestspring/exception/myExceptions/ServerConnectionErrorCode.java
@@ -6,9 +6,10 @@ import org.springframework.http.HttpStatus;
 
 @AllArgsConstructor
 @Getter
-public enum GameRuleErrorCode implements ErrorCode {
+public enum ServerConnectionErrorCode implements ErrorCode {
     //GAME RULES
-    INVALID_CARD_SUBMISSION(HttpStatus.BAD_REQUEST, "손에 없는 카드를 제출했습니다");
+    BAD_USER_ACCESS(HttpStatus.BAD_REQUEST, "잘못된 유저의 접근입니다"),
+    BAD_ROOM_ACCESS(HttpStatus.BAD_REQUEST, "잘못된 방의 접근입니다");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/socketTest/socketTestspring/exception/myExceptions/classes/InvalidJwtException.java
+++ b/src/main/java/socketTest/socketTestspring/exception/myExceptions/classes/InvalidJwtException.java
@@ -1,7 +1,0 @@
-package socketTest.socketTestspring.exception.myExceptions.classes;
-
-public class InvalidJwtException extends RuntimeException {
-    public InvalidJwtException(String message) {
-        super(message);
-    }
-}

--- a/src/main/java/socketTest/socketTestspring/exception/myExceptions/classes/JwtNotFoundException.java
+++ b/src/main/java/socketTest/socketTestspring/exception/myExceptions/classes/JwtNotFoundException.java
@@ -1,7 +1,0 @@
-package socketTest.socketTestspring.exception.myExceptions.classes;
-
-public class JwtNotFoundException extends RuntimeException {
-    public JwtNotFoundException(String message) {
-        super(message);
-    }
-}

--- a/src/main/java/socketTest/socketTestspring/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/socketTest/socketTestspring/filter/JwtAuthenticationFilter.java
@@ -1,5 +1,9 @@
 package socketTest.socketTestspring.filter;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.micrometer.common.lang.NonNullApi;
+import jakarta.annotation.Nullable;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -14,18 +18,18 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
-import socketTest.socketTestspring.exception.MyException;
-import socketTest.socketTestspring.exception.myExceptions.GameRuleErrorCode;
-import socketTest.socketTestspring.exception.myExceptions.classes.InvalidJwtException;
-import socketTest.socketTestspring.exception.myExceptions.classes.JwtNotFoundException;
+import socketTest.socketTestspring.exception.MyResponse;
+import socketTest.socketTestspring.exception.myExceptions.ErrorCode;
+import socketTest.socketTestspring.exception.myExceptions.JwtErrorCode;
 import socketTest.socketTestspring.service.JwtMemberDetailsService;
 import socketTest.socketTestspring.tools.JwtTokenUtil;
 
 import java.io.IOException;
 
-//Transactional 추가 시 오류 발생. 참고 : https://stackoverflow.com/questions/60267832/nullpointerexception-spring-security-filter-failed
+// Transactional 추가 시 오류 발생. 참고 : https://stackoverflow.com/questions/60267832/nullpointerexception-spring-security-filter-failed
 @Slf4j
 @Component
+@NonNullApi
 @AllArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtMemberDetailsService jwtMemberDetailsService;
@@ -33,38 +37,60 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String servletPath = request.getServletPath();
+        if (servletPath.equals("/api/users/login") || servletPath.equals("/api/users/join")) { //early return logic
+            filterChain.doFilter(request, response);
+            return;
+        }
         String token = extractJwtFromRequest(request);
+        if (token == null) {
+            log.error("Token does not exists.");
+            filterExceptionHandler(response, JwtErrorCode.TOKEN_NOT_EXIST);
+            return;
+        }
         try {
-            if (token == null) throw new JwtNotFoundException("헤더에 토큰이 없습니다.");
-            String memberId = jwtTokenUtil.getMemberId(token);
-            log.info("get memberId : {}", memberId);
+            String memberId = jwtTokenUtil.getMemberId(token); // Possible exception: ExpiredJwtException may occur.
+            log.info("get memberId : {}", memberId); //memberId can be null
 
-            if (memberId == null) throw new InvalidJwtException("멤버 아이디가 없습니다.");
-            UserDetails memberDetails = jwtMemberDetailsService.loadUserByUsername(memberId);
-            log.info("created UserDetails : {}", memberDetails);
+            UserDetails memberDetails = jwtMemberDetailsService.loadUserByUsername(memberId); // Possible exception: UsernameNotFoundException may occur.
+            log.info("created UserDetails : {}", memberDetails); //memberDetails must not be null
 
-            if (!jwtTokenUtil.validateToken(token, memberDetails)) throw new InvalidJwtException("옳바른 토큰이 아닙니다.");
+            if (!jwtTokenUtil.validateToken(token, memberDetails)) {
+                log.error("올바른 토큰이 아닙니다 : {}", token);
+                filterExceptionHandler(response, JwtErrorCode.BAD_TOKEN);
+                return;
+            }
 
-            log.info("유저 정보가 Security Context에 저장됩니다.");
+            log.info("유저 정보가 Security Context 에 저장됩니다.");
             UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken
                     = new UsernamePasswordAuthenticationToken(memberDetails, null, memberDetails.getAuthorities());
             usernamePasswordAuthenticationToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
-
             SecurityContextHolder.getContext().setAuthentication(usernamePasswordAuthenticationToken);
 
-        } catch (JwtNotFoundException e) {
-            log.warn("You are not authorized : {}", e.getMessage());
-        } catch (InvalidJwtException e) {
-            log.error("Invalid token : {}", e.getMessage());
-            throw new MyException(GameRuleErrorCode.BAD_TOKEN_ACCESS, "Invalid token");
-        } catch (UsernameNotFoundException e) {
-            log.error("Cannot find any users with this token {}", token);
-            throw new MyException(GameRuleErrorCode.BAD_USER_ACCESS, "");
+            filterChain.doFilter(request, response);
         }
-
-        filterChain.doFilter(request, response);
+        catch(ExpiredJwtException e) {
+            log.error("Expired Jwt token : {}", e.getMessage());
+            filterExceptionHandler(response, JwtErrorCode.TOKEN_EXPIRED);
+        }
+        catch(UsernameNotFoundException e) {
+            log.error("멤버 아이디가 없습니다 : {}", e.getMessage());
+            filterExceptionHandler(response, JwtErrorCode.BAD_TOKEN);
+        }
     }
 
+    public void filterExceptionHandler(HttpServletResponse response, ErrorCode error) {
+        response.setStatus(error.getHttpStatus().value());
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        try {
+            String json = new ObjectMapper().writeValueAsString(MyResponse.error(error.getMessage()));
+            response.getWriter().write(json);
+        } catch (Exception e) {
+            log.error(e.getMessage());
+        }
+    }
+    @Nullable
     private String extractJwtFromRequest(HttpServletRequest request) {
         String bearerToken = request.getHeader(HttpHeaders.AUTHORIZATION); //Authorization
         if (bearerToken != null && bearerToken.startsWith("Bearer ")) {

--- a/src/main/java/socketTest/socketTestspring/service/MemberService.java
+++ b/src/main/java/socketTest/socketTestspring/service/MemberService.java
@@ -7,7 +7,7 @@ import org.springframework.transaction.annotation.Transactional;
 import socketTest.socketTestspring.domain.Member;
 import socketTest.socketTestspring.dto.member.join.MemberJoinRequest;
 import socketTest.socketTestspring.exception.MyException;
-import socketTest.socketTestspring.exception.myExceptions.GameRuleErrorCode;
+import socketTest.socketTestspring.exception.myExceptions.ServerConnectionErrorCode;
 import socketTest.socketTestspring.repository.MemberRepository;
 import socketTest.socketTestspring.tools.JwtTokenUtil;
 
@@ -24,7 +24,7 @@ public class MemberService {
     public Member join(MemberJoinRequest memberJoinRequest){
         memberRepository.findByMemberId(memberJoinRequest.memberId())
                 .ifPresent(member1 -> {
-                    throw new MyException(GameRuleErrorCode.BAD_USER_ACCESS, "user Id is duplicated");
+                    throw new MyException(ServerConnectionErrorCode.BAD_USER_ACCESS, "user Id is duplicated");
                 });
         String encodedPwd = encoder.encode(memberJoinRequest.memberPassword());
         Member member = new Member(memberJoinRequest.memberId(), encodedPwd, memberJoinRequest.memberName());
@@ -35,9 +35,9 @@ public class MemberService {
 
     public String login(String memberId, String memberPassword){
         Member member = memberRepository.findByMemberId(memberId)
-                .orElseThrow(() ->  new MyException(GameRuleErrorCode.BAD_USER_ACCESS, "wrong user Id or Password"));
+                .orElseThrow(() ->  new MyException(ServerConnectionErrorCode.BAD_USER_ACCESS, "wrong user Id or Password"));
         if(!encoder.matches(memberPassword, member.getMemberPassword())){
-            throw new MyException(GameRuleErrorCode.BAD_USER_ACCESS, "wrong user Id or Password");
+            throw new MyException(ServerConnectionErrorCode.BAD_USER_ACCESS, "wrong user Id or Password");
         }
 
         return jwtTokenUtil.createToken(memberId);

--- a/src/main/java/socketTest/socketTestspring/service/RoomService.java
+++ b/src/main/java/socketTest/socketTestspring/service/RoomService.java
@@ -10,7 +10,7 @@ import socketTest.socketTestspring.dto.room.create.RoomCreateResponse;
 import socketTest.socketTestspring.dto.room.delete.RoomDeleteRequest;
 import socketTest.socketTestspring.dto.room.delete.RoomDeleteResponse;
 import socketTest.socketTestspring.exception.MyException;
-import socketTest.socketTestspring.exception.myExceptions.GameRuleErrorCode;
+import socketTest.socketTestspring.exception.myExceptions.ServerConnectionErrorCode;
 import socketTest.socketTestspring.repository.RoomRepository;
 
 
@@ -30,10 +30,10 @@ public class RoomService {
     @Transactional
     public RoomDeleteResponse deleteRoom(RoomDeleteRequest roomDeleteRequest) {
         Room deleteRoom = roomRepository.findByRoomId(roomDeleteRequest.roomId())
-                .orElseThrow(() -> new MyException(GameRuleErrorCode.BAD_ROOM_ACCESS, "Cannot find any room with this roomId"));
+                .orElseThrow(() -> new MyException(ServerConnectionErrorCode.BAD_ROOM_ACCESS, "Cannot find any room with this roomId"));
 
         String memberId = SecurityContextHolder.getContext().getAuthentication().getName();
-        if(!memberId.equals(deleteRoom.getOwnerMemberId())) throw new MyException(GameRuleErrorCode.BAD_USER_ACCESS, "This user is not the room owner");
+        if(!memberId.equals(deleteRoom.getOwnerMemberId())) throw new MyException(ServerConnectionErrorCode.BAD_USER_ACCESS, "This user is not the room owner");
 
         roomRepository.delete(deleteRoom);
         return new RoomDeleteResponse("room deleted");

--- a/src/main/java/socketTest/socketTestspring/tools/JwtTokenUtil.java
+++ b/src/main/java/socketTest/socketTestspring/tools/JwtTokenUtil.java
@@ -61,7 +61,7 @@ public class JwtTokenUtil {
                     .getBody();
             return claims.get(MEMBER).toString();
         } catch(ExpiredJwtException e) {
-            log.warn("expired Jwt token. Need to refresh");
+            log.error("expired Jwt token. Need to refresh");
             throw e;
         } catch (Exception e) {
             log.error("Cannot find any member with this token");


### PR DESCRIPTION
1. README.md 파일 업데이트
2. application.properties의 secret key 이름 일관성있게 변경
3. ErrorCode 카테고리별로 세분화. classes 하위파일 삭제
4. JwtFilter 로직 변경. basic try-catch 대신 exception handler 메소드 구현(구현과정에서 위의 "classes/**" deprecated)
5. exception handler 메소드에서 클라이언트에게 http status 및 메세지 발송하는거 구현. SecurityConfig의 TODO 삭제
6. ROLE_USER 을 default value로 설정, 이제 모든 유저들은 회원가입 시 USER role을 부여받음
7. ExceptionManager 클래스에서 추상클래스를 DI하지 않던 버그 수정
8. JwtTokenUtil의 init 메소드 PostConstruct 되지 않던 버그 수정
9. JwtTokenUtil의 isValidToken 미사용 메소드로 변경됨. getMemberId가 논리적으로 해당 메소드를 포함하고 있음. 추후 사용될 가능성이 있기에 삭제하지 않았음.
10. MemberController에 /refresh 경로 추가(미구현)